### PR TITLE
internal.NewDBの引数変更

### DIFF
--- a/internal/app.go
+++ b/internal/app.go
@@ -15,7 +15,8 @@ func RunApp(ctx context.Context) error {
 		return err
 	}
 
-	// db, err := NewDB(ctx, cfg)
+	// dsn := internal.BuildDSN(cfg)
+	// db, err := NewDB(ctx, dsn)
 	// if err != nil {
 	// 	return err
 	// }

--- a/internal/db.go
+++ b/internal/db.go
@@ -10,8 +10,7 @@ import (
 	"github.com/uptrace/bun/driver/pgdriver"
 )
 
-func NewDB(ctx context.Context, cfg *Config) (*bun.DB, error) {
-	dsn := buildDSN(cfg)
+func NewDB(ctx context.Context, dsn string) (*bun.DB, error) {
 	sqldb := sql.OpenDB(pgdriver.NewConnector(pgdriver.WithDSN(dsn)))
 	if err := sqldb.PingContext(ctx); err != nil {
 		return nil, err
@@ -20,6 +19,6 @@ func NewDB(ctx context.Context, cfg *Config) (*bun.DB, error) {
 	return db, nil
 }
 
-func buildDSN(cfg *Config) string {
+func BuildDSN(cfg *Config) string {
 	return fmt.Sprintf("postgres://%[1]v:%[2]v@db/%[1]v?sslmode=disable", cfg.DBUser, cfg.DBPassword)
 }


### PR DESCRIPTION
Configに依存せず、DSNのみでDBを作成可能にする。
ついでにConfigからDSNを作る関数`BuildDSN`をexportする。この関数の中身は雑なのでまた今度直すかも
(DSNと言っているが、実際に使っているのは接続文字列というものらしい。しかし、[Goの公式のsqlパッケージ](https://pkg.go.dev/database/sql#Open)で接続文字列を`dataSourceName`と命名しているっぽいので、それに従うことにする)