### PR TITLE
dbのテーブルを自動で削除&作成する

### DIFF
--- a/internal/app.go
+++ b/internal/app.go
@@ -15,12 +15,15 @@ func RunApp(ctx context.Context) error {
 		return err
 	}
 
-	// dsn := internal.BuildDSN(cfg)
-	// db, err := NewDB(ctx, dsn)
-	// if err != nil {
-	// 	return err
-	// }
-	// defer db.Close()
+	models := []any{ // 新しいテーブル(モデル)を作ったらここに書きましょう
+		(*User)(nil),
+		// (*NewModelType)(nil),
+	}
+	db, err := NewDB(ctx, BuildDSN(cfg), models)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
 
 	e := echo.New()
 	RegisterRoute(e)

--- a/internal/db.go
+++ b/internal/db.go
@@ -10,12 +10,15 @@ import (
 	"github.com/uptrace/bun/driver/pgdriver"
 )
 
-func NewDB(ctx context.Context, dsn string) (*bun.DB, error) {
+func NewDB(ctx context.Context, dsn string, models []any) (*bun.DB, error) {
 	sqldb := sql.OpenDB(pgdriver.NewConnector(pgdriver.WithDSN(dsn)))
 	if err := sqldb.PingContext(ctx); err != nil {
 		return nil, err
 	}
 	db := bun.NewDB(sqldb, pgdialect.New())
+	if err := db.ResetModel(ctx, models...); err != nil {
+		return nil, err
+	}
 	return db, nil
 }
 


### PR DESCRIPTION
dbを起動してテーブルをリセットする(だけ)の機能を追加。

登録されたデータは起動時に全て削除されるので注意。
bunのモデルを使ってテーブルを作る。internal/app.go 内に[モデルを列挙する場所](https://github.com/ynm3n/nemmy-backend-sandbox/compare/develop?expand=1#diff-3f872009f3ac917776678f1061bf212728abc5b7fc719b80338d702fb909497fR18)があるので、新しいテーブルを作った時はそこを適宜更新する(手動)。