### PR TITLE
マイグレーションファイル作成ツールを実装

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -31,3 +31,8 @@ tasks:
   psql:
     cmds:
       - docker compose exec db psql -h localhost -d $POSTGRES_USER -U $POSTGRES_USER
+
+  migrate:create:
+    desc: Create a bun migration file(Go). A migration name passed as an argument is required.
+    cmds:
+      - go run cmd/migration/create/main.go --name {{.CLI_ARGS}}

--- a/cmd/migration/create/README.md
+++ b/cmd/migration/create/README.md
@@ -1,0 +1,3 @@
+# create bun migration file (Go)
+- This command must be executed outside docker container
+- A migration file will be created in `internal/migrations`

--- a/cmd/migration/create/main.go
+++ b/cmd/migration/create/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/uptrace/bun/migrate"
+	"github.com/ynm3n/go-bun-exercise/internal/migrations"
+)
+
+var name string
+
+const usage = "Migration name. Except timestamp because auto added."
+
+func main() {
+	flag.Usage = func() {
+		fmt.Println("This is migration file creator")
+		fmt.Println("Usage:")
+		flag.PrintDefaults()
+	}
+	flag.StringVar(&name, "name", "", usage)
+	flag.Parse()
+
+	m := migrate.NewMigrator(nil, migrations.Migrations)
+	if _, err := m.CreateGoMigration(context.Background(), name); err != nil {
+		panic(err)
+	}
+}

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -1,0 +1,5 @@
+package migrations
+
+import "github.com/uptrace/bun/migrate"
+
+var Migrations = migrate.NewMigrations()


### PR DESCRIPTION
`task migrate:create -- マイグレーション名`
とすると`internal/migrations`ディレクトリにマイグレーションファイルが生成されます