### PR TITLE
初めてのマイグレーション定義用コード

### DIFF
--- a/internal/migrations/20231205113428_init.go
+++ b/internal/migrations/20231205113428_init.go
@@ -1,0 +1,50 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+	"github.com/ynm3n/go-bun-exercise/internal/models"
+)
+
+func init() {
+	Migrations.MustRegister(func(ctx context.Context, db *bun.DB) error {
+		if _, err := db.NewCreateTable().
+			Model((*models.User)(nil)).
+			Exec(ctx); err != nil {
+			return err
+		}
+		if _, err := db.NewCreateTable().
+			Model((*models.Subject)(nil)).
+			WithForeignKeys().
+			Exec(ctx); err != nil {
+			return err
+		}
+		if _, err := db.NewCreateTable().
+			Model((*models.Record)(nil)).
+			WithForeignKeys().
+			Exec(ctx); err != nil {
+			return err
+		}
+		fmt.Println("マイグレーション完了")
+		return nil
+	}, func(ctx context.Context, db *bun.DB) error {
+		if _, err := db.NewDropTable().
+			Model((*models.Record)(nil)).
+			Exec(ctx); err != nil {
+			return err
+		}
+		if _, err := db.NewDropTable().
+			Model((*models.Subject)(nil)).
+			Exec(ctx); err != nil {
+			return err
+		}
+		if _, err := db.NewDropTable().
+			Model((*models.User)(nil)).
+			Exec(ctx); err != nil {
+			return err
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
外部キー制約はついてるがON DELETEやON UPDATEの設定をしていないので、後で決めて設定する

マイグレーション定義のファイルは `task migrate:create -- 名前` で `internal/migrations` に生成される