### PR TITLE
マイグレーション機能の実装

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,23 @@
 # syntax=docker/dockerfile:1
-FROM golang:latest AS builder
-WORKDIR /build
+FROM golang:latest AS base
+WORKDIR /base
 COPY . .
 RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download -x
+
+FROM base AS migrate-builder
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -ldflags="-s -w" -trimpath ./cmd/migrate
+FROM debian:stable-slim AS migrate
+WORKDIR /migrate
+COPY --from=migrate-builder /base/migrate .
+
+FROM base AS app-builder
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     go build -ldflags="-s -w" -trimpath ./cmd/app
-
 FROM debian:stable-slim AS app
 WORKDIR /app
-COPY --from=builder /build/app .
+COPY --from=app-builder /base/app .
 CMD [ "./app" ]

--- a/cmd/migrate/LICENSE
+++ b/cmd/migrate/LICENSE
@@ -1,0 +1,24 @@
+Copyright (c) 2020 Vladimir Mihailenco. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/cmd/migrate/README.md
+++ b/cmd/migrate/README.md
@@ -1,0 +1,1 @@
+This program for migrating database was created based on the [bun-realworld-app](https://github.com/go-bun/bun-realworld-app/blob/9b04b5d46d1b9ddf005ccf3aa187082a42a5ae4a/cmd/bun/main.go). There is the license in this directory.

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/uptrace/bun/extra/bundebug"
+	"github.com/uptrace/bun/migrate"
+	"github.com/ynm3n/go-bun-exercise/internal"
+	"github.com/ynm3n/go-bun-exercise/internal/migrations"
+
+	"github.com/urfave/cli/v2"
+)
+
+func main() {
+	ctx := context.Background()
+	cfg, err := internal.GetConfig()
+	if err != nil {
+		panic(err)
+	}
+	dsn := internal.BuildDSN(cfg)
+	db, err := internal.NewDB(ctx, dsn)
+	if err != nil {
+		panic(err)
+	}
+	db.AddQueryHook(bundebug.NewQueryHook(
+		bundebug.WithEnabled(false),
+		bundebug.FromEnv(""),
+	))
+
+	cmds := newCommands(migrate.NewMigrator(db, migrations.Migrations))
+	app := &cli.App{Commands: cmds}
+	if err := app.Run(os.Args); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func newCommands(migrator *migrate.Migrator) []*cli.Command {
+	return []*cli.Command{
+		{
+			Name:  "init",
+			Usage: "create migration tables",
+			Action: func(c *cli.Context) error {
+				return migrator.Init(c.Context)
+			},
+		},
+		{
+			Name:  "migrate",
+			Usage: "migrate database",
+			Action: func(c *cli.Context) error {
+				if err := migrator.Lock(c.Context); err != nil {
+					return err
+				}
+				defer migrator.Unlock(c.Context) //nolint:errcheck
+
+				group, err := migrator.Migrate(c.Context)
+				if err != nil {
+					return err
+				}
+				if group.IsZero() {
+					fmt.Printf("there are no new migrations to run (database is up to date)\n")
+					return nil
+				}
+				fmt.Printf("migrated to %s\n", group)
+				return nil
+			},
+		},
+		{
+			Name:  "rollback",
+			Usage: "rollback the last migration group",
+			Action: func(c *cli.Context) error {
+				if err := migrator.Lock(c.Context); err != nil {
+					return err
+				}
+				defer migrator.Unlock(c.Context) //nolint:errcheck
+
+				group, err := migrator.Rollback(c.Context)
+				if err != nil {
+					return err
+				}
+				if group.IsZero() {
+					fmt.Printf("there are no groups to roll back\n")
+					return nil
+				}
+				fmt.Printf("rolled back %s\n", group)
+				return nil
+			},
+		},
+		{
+			Name:  "lock",
+			Usage: "lock migrations",
+			Action: func(c *cli.Context) error {
+				return migrator.Lock(c.Context)
+			},
+		},
+		{
+			Name:  "unlock",
+			Usage: "unlock migrations",
+			Action: func(c *cli.Context) error {
+				return migrator.Unlock(c.Context)
+			},
+		},
+		{
+			Name:  "status",
+			Usage: "print migrations status",
+			Action: func(c *cli.Context) error {
+				ms, err := migrator.MigrationsWithStatus(c.Context)
+				if err != nil {
+					return err
+				}
+				fmt.Printf("migrations: %s\n", ms)
+				fmt.Printf("unapplied migrations: %s\n", ms.Unapplied())
+				fmt.Printf("last migration group: %s\n", ms.LastGroup())
+				return nil
+			},
+		},
+		{
+			Name:  "mark_applied",
+			Usage: "mark migrations as applied without actually running them",
+			Action: func(c *cli.Context) error {
+				group, err := migrator.Migrate(c.Context, migrate.WithNopMigration())
+				if err != nil {
+					return err
+				}
+				if group.IsZero() {
+					fmt.Printf("there are no new migrations to mark as applied\n")
+					return nil
+				}
+				fmt.Printf("marked as applied %s\n", group)
+				return nil
+			},
+		},
+	}
+}

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,6 +3,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      target: app
     ports:
       - "${APP_HOST_PORT}:${APP_CONTAINER_PORT}"
     depends_on:
@@ -28,6 +29,19 @@ services:
       timeout: 3s
       retries: 5
       start_period: 1s
+  migrate:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: migrate
+    profiles:
+      - migrate
+    depends_on:
+      db:
+        condition: service_healthy
+    env_file:
+      - .env
+    entrypoint: ./migrate
 
 volumes:
   db-data:


### PR DESCRIPTION
サーバー起動時以外のタイミングでもマイグレーションしたい場合に使う
rollbackやstatus、migrateなどのサブコマンドが使える(`cmd/migrate/main.go`内の`newCommands`関数を参照)

`docker compose run --rm migrate サブコマンド`
のように実行する。Taskfileはまだ書いてない