### PR TITLE
外部キーに ON DELETE CASCADE を追加

### DIFF
--- a/internal/migrations/20231205113428_init.go
+++ b/internal/migrations/20231205113428_init.go
@@ -2,7 +2,6 @@ package migrations
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/uptrace/bun"
 	"github.com/ynm3n/go-bun-exercise/internal/models"
@@ -27,7 +26,6 @@ func init() {
 			Exec(ctx); err != nil {
 			return err
 		}
-		fmt.Println("マイグレーション完了")
 		return nil
 	}, func(ctx context.Context, db *bun.DB) error {
 		if _, err := db.NewDropTable().

--- a/internal/migrations/20231205113428_init.go
+++ b/internal/migrations/20231205113428_init.go
@@ -17,13 +17,13 @@ func init() {
 		}
 		if _, err := db.NewCreateTable().
 			Model((*models.Subject)(nil)).
-			WithForeignKeys().
+			ForeignKey(`("user_id") REFERENCES "users" ("id") ON DELETE CASCADE`).
 			Exec(ctx); err != nil {
 			return err
 		}
 		if _, err := db.NewCreateTable().
 			Model((*models.Record)(nil)).
-			WithForeignKeys().
+			ForeignKey(`("subject_id") REFERENCES "subjects" ("id") ON DELETE CASCADE`).
 			Exec(ctx); err != nil {
 			return err
 		}


### PR DESCRIPTION
Resolve: #35 
物理削除
`ON DELETE CASCADE`を使って

- ユーザー削除時に勉強科目
- 勉強科目削除時に勉強時間データ

を削除する