### PR TITLE
マイグレーション用のtaskを別フォルダに分離

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,5 +1,10 @@
 version: "3"
 
+includes:
+  migrate:
+    taskfile: ./taskfile/migrate.yml
+    aliases: [mg]
+
 dotenv: [".env"]
 
 tasks:
@@ -31,8 +36,3 @@ tasks:
   psql:
     cmds:
       - docker compose exec db psql -h localhost -d $POSTGRES_USER -U $POSTGRES_USER
-
-  migrate:create:
-    desc: Create a bun migration file(Go). A migration name passed as an argument is required.
-    cmds:
-      - go run cmd/migrate/create/main.go --name {{.CLI_ARGS}}

--- a/taskfile/migrate.yml
+++ b/taskfile/migrate.yml
@@ -1,0 +1,24 @@
+version: "3"
+
+tasks:
+  default:
+    desc: Run all migrations that have not been applied yet.
+    cmds:
+      - docker compose run --rm migrate migrate
+
+  rollback:
+    cmds:
+      - docker compose run --rm migrate rollback
+
+  init:
+    cmds:
+      - docker compose run --rm migrate init
+
+  status:
+    cmds:
+      - docker compose run --rm migrate status
+
+  create:
+    desc: Create a bun migration file(Go). A migration name passed as an argument is required.
+    cmds:
+      - go run cmd/migrate/create/main.go --name {{.CLI_ARGS}}


### PR DESCRIPTION
マイグレーションのためのTaskは別ファイル(`taskfile`ディレクトリ以下)に分けた

`task migrate:default`
`task mg:default`
`task mg`
のどれかでマイグレーションを適用できる

`task migrate:rollback`
`task mg:rollback`
のどちらかでマイグレーションのロールバックができる

他にもいくつかコマンドがある

mainにマージすべきかdevelopにマージすべきか悩み中…