### PR TITLE
継続不可能なエラーの処理方法を微調整

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"log"
-	"os"
 
 	"github.com/ynm3n/go-bun-exercise/internal"
 )
@@ -15,7 +14,6 @@ func main() {
 		log.Fatal(err)
 	}
 	if err := internal.RunApp(ctx, cfg); err != nil {
-		panic(err) // TODO: エラー処理
-		os.Exit(1)
+		log.Fatal(err)
 	}
 }

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"log"
 	"os"
 
 	"github.com/ynm3n/go-bun-exercise/internal"
@@ -9,7 +10,11 @@ import (
 
 func main() {
 	ctx := context.Background()
-	if err := internal.RunApp(ctx); err != nil {
+	cfg, err := internal.GetConfig()
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := internal.RunApp(ctx, cfg); err != nil {
 		panic(err) // TODO: エラー処理
 		os.Exit(1)
 	}

--- a/internal/app.go
+++ b/internal/app.go
@@ -5,12 +5,7 @@ import (
 	"fmt"
 )
 
-func RunApp(ctx context.Context) error {
-	cfg, err := GetConfig()
-	if err != nil {
-		return err
-	}
-
+func RunApp(ctx context.Context, cfg *Config) error {
 	db, err := NewDB(ctx, BuildDSN(cfg))
 	if err != nil {
 		return err

--- a/internal/app.go
+++ b/internal/app.go
@@ -8,18 +8,18 @@ import (
 func RunApp(ctx context.Context, cfg *Config) error {
 	db, err := NewDB(ctx, BuildDSN(cfg))
 	if err != nil {
-		return err
+		return fmt.Errorf("RunApp: %w", err)
 	}
 	defer db.Close()
 	if err := Migrate(ctx, db); err != nil {
-		return err
+		return fmt.Errorf("RunApp: %w", err)
 	}
 
 	e := NewEcho(cfg, db)
 
 	addr := fmt.Sprintf("0.0.0.0:%v", cfg.Port)
 	if err := e.Start(addr); err != nil {
-		return err
+		return fmt.Errorf("RunApp: %w", err)
 	}
 
 	return nil

--- a/internal/config.go
+++ b/internal/config.go
@@ -1,6 +1,10 @@
 package internal
 
-import "github.com/caarlos0/env/v10"
+import (
+	"fmt"
+
+	"github.com/caarlos0/env/v10"
+)
 
 type Config struct {
 	DBUser      string `env:"POSTGRES_USER" envDefault:"postgres"`
@@ -12,7 +16,7 @@ type Config struct {
 func GetConfig() (*Config, error) {
 	cfg := new(Config)
 	if err := env.Parse(cfg); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("GetConfig: %w", err)
 	}
 	return cfg, nil
 }

--- a/internal/db.go
+++ b/internal/db.go
@@ -8,7 +8,7 @@ import (
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/dialect/pgdialect"
 	"github.com/uptrace/bun/driver/pgdriver"
-	migratepkg "github.com/uptrace/bun/migrate"
+	"github.com/uptrace/bun/migrate"
 
 	"github.com/ynm3n/go-bun-exercise/internal/migrations"
 )
@@ -27,7 +27,7 @@ func BuildDSN(cfg *Config) string {
 }
 
 func Migrate(ctx context.Context, db *bun.DB) error {
-	migrator := migratepkg.NewMigrator(db, migrations.Migrations)
+	migrator := migrate.NewMigrator(db, migrations.Migrations)
 	if err := migrator.Init(ctx); err != nil {
 		return fmt.Errorf("Migrate: %w", err)
 	}

--- a/internal/db.go
+++ b/internal/db.go
@@ -16,7 +16,7 @@ import (
 func NewDB(ctx context.Context, dsn string) (*bun.DB, error) {
 	sqldb := sql.OpenDB(pgdriver.NewConnector(pgdriver.WithDSN(dsn)))
 	if err := sqldb.PingContext(ctx); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("NewDB: %w", err)
 	}
 	db := bun.NewDB(sqldb, pgdialect.New())
 	return db, nil
@@ -29,10 +29,10 @@ func BuildDSN(cfg *Config) string {
 func Migrate(ctx context.Context, db *bun.DB) error {
 	migrator := migratepkg.NewMigrator(db, migrations.Migrations)
 	if err := migrator.Init(ctx); err != nil {
-		return err
+		return fmt.Errorf("Migrate: %w", err)
 	}
 	if _, err := migrator.Migrate(ctx); err != nil {
-		return err
+		return fmt.Errorf("Migrate: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
resolve: #28 

- エラーメッセージをちょっと変えた
  - `fmt.Errorf`でラップすることで、どこでエラーが発生したかわかるようになる
- おまけ
  - `*internal.Config`を外から渡す形に変更
  - `panic`を`log.Fatal`に変えてみた
    - なんとなく…
    - 少なくとも害はないと思う
  - `github.com/uptrace/bun/migrate`のエイリアスを削除
    - 不要になったので

ルーティングのエラー処理はまだやってません。まだルーティングをちゃんと書いてないため
おまけが多くてすいません、configの取得位置が変わったこと以外は重要度低いです